### PR TITLE
Add notice indicating cairo-rs-py is in use

### DIFF
--- a/src/starkware/cairo/lang/vm/cairo_run.py
+++ b/src/starkware/cairo/lang/vm/cairo_run.py
@@ -33,7 +33,7 @@ def main():
     start_time = time.time()
 
     parser = argparse.ArgumentParser(description="A tool to run Cairo programs.")
-    parser.add_argument("-v", "--version", action="version", version=f"%(prog)s {__version__}")
+    parser.add_argument("-v", "--version", action="version", version=f"%(prog)s {__version__} (with cairo-rs-py)")
     parser.add_argument(
         "--program",
         type=argparse.FileType("r"),

--- a/src/starkware/starknet/cli/starknet_cli.py
+++ b/src/starkware/starknet/cli/starknet_cli.py
@@ -1493,7 +1493,7 @@ async def main():
         "tx_status": tx_status,
     }
     parser = argparse.ArgumentParser(description="A tool to communicate with StarkNet.")
-    parser.add_argument("-v", "--version", action="version", version=f"%(prog)s {__version__}")
+    parser.add_argument("-v", "--version", action="version", version=f"%(prog)s {__version__} (with cairo-rs-py)")
     parser.add_argument("--network", type=str, help="The name of the StarkNet network.")
     parser.add_argument(
         "--network_id",


### PR DESCRIPTION
Add notice indicating `cairo-rs-py` is in use to the output of `--version` option for the `starknet` and `cairo-run` scripts.