### PR TITLE
Change calls to get_ap to use runner properties

### DIFF
--- a/src/starkware/starknet/core/os/class_hash.py
+++ b/src/starkware/starknet/core/os/class_hash.py
@@ -268,13 +268,13 @@ Got {type(ex).__name__} exception during the execution of {func_name}:
         n_ret_vals = n_explicit_ret_vals + n_implicit_ret_vals
         implicit_retvals = tuple(
             runner.get_range(
-                runner.get_ap() - n_ret_vals, n_implicit_ret_vals
+                runner.vm.run_context.ap - n_ret_vals, n_implicit_ret_vals
             )
         )
 
         explicit_retvals = tuple(
             runner.get_range(
-                runner.get_ap() - n_explicit_ret_vals, n_explicit_ret_vals
+                runner.vm.run_context.ap - n_explicit_ret_vals, n_explicit_ret_vals
             )
         )
 

--- a/src/starkware/starknet/core/os/os_utils.py
+++ b/src/starkware/starknet/core/os/os_utils.py
@@ -71,7 +71,7 @@ def validate_and_process_os_context(
     """
     # CAIRO-RS VERSION
     try:
-        os_context_end = runner.get_ap() - 2
+        os_context_end = runner.vm.run_context.ap - 2
         stack_ptr = os_context_end
         # The returned values are os_context, retdata_size, retdata_ptr.
         stack_ptr = runner.get_builtins_final_stack(stack_ptr)

--- a/src/starkware/starknet/core/os/segment_utils.py
+++ b/src/starkware/starknet/core/os/segment_utils.py
@@ -23,7 +23,7 @@ def get_os_segment_ptr_range(
     # The returned values are os_context, retdata_size, retdata_ptr.
     # CAIRO-RS VERSION
     try:
-        os_context_end = runner.get_ap() - 2
+        os_context_end = runner.vm.run_context.ap - 2
     except:
     # ORIGINAL VERSION
         os_context_end = runner.vm.run_context.ap - 2


### PR DESCRIPTION
[PR 157](https://github.com/lambdaclass/cairo-rs-py/pull/157/files) from cairo-rs-py implemented support for `runner.vm.run_context.ap`. This PR changes calls to `runner.get_ap()` into `runner.vm.run_context.ap`.